### PR TITLE
Add support for concatenating/joining Hash40 values

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,7 +1,7 @@
 use std::fmt::{Display, Formatter};
 use std::num::ParseIntError;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ParseHashError {
     /// The error returned when the numeric hash string doesn't begin with "0x"
     MissingPrefix,
@@ -9,7 +9,7 @@ pub enum ParseHashError {
     ParseError(ParseIntError),
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FromLabelError {
     /// The error returned only when the static label map is bidirectional, and a label
     /// cannot be matched to a hash

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,6 +114,10 @@ impl Hash40 {
     pub fn label_map() -> Arc<Mutex<LabelMap>> {
         LABELS.clone()
     }
+
+    pub const fn concat(self, other: Hash40) -> Hash40 {
+        Hash40(algorithm::hash40_concat(self.0, other.0))
+    }
 }
 
 impl FromStr for Hash40 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,8 +115,18 @@ impl Hash40 {
         LABELS.clone()
     }
 
+    /// Concatenates two Hash40 values, so that the resulting length and CRC would be the same if
+    /// the original data was all hashed together.
     pub const fn concat(self, other: Hash40) -> Hash40 {
         Hash40(algorithm::hash40_concat(self.0, other.0))
+    }
+
+    /// A convenience method for concatenating two Hash40s separated by a path separator
+    pub const fn join_path(self, other: Hash40) -> Hash40 {
+        Hash40(algorithm::hash40_concat(
+            algorithm::hash40_concat(self.0, algorithm::hash40("/")),
+            other.0,
+        ))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,16 +117,18 @@ impl Hash40 {
 
     /// Concatenates two Hash40 values, so that the resulting length and CRC would be the same if
     /// the original data was all hashed together.
-    pub const fn concat(self, other: Hash40) -> Hash40 {
+    pub const fn concat(self, other: Self) -> Hash40 {
         Hash40(algorithm::hash40_concat(self.0, other.0))
     }
 
+    /// A convenience method for concatenating a string to a Hash40
+    pub const fn concat_str(self, other: &str) -> Self {
+        self.concat(hash40(other))
+    }
+
     /// A convenience method for concatenating two Hash40s separated by a path separator
-    pub const fn join_path(self, other: Hash40) -> Hash40 {
-        Hash40(algorithm::hash40_concat(
-            algorithm::hash40_concat(self.0, algorithm::hash40("/")),
-            other.0,
-        ))
+    pub const fn join_path(self, other: Self) -> Hash40 {
+        self.concat_str("/").concat(other)
     }
 }
 


### PR DESCRIPTION
Also adds a `Derive` on `Eq` as per a clippy suggestion.

Also adds `join_path` as a convenience method for joining together two hashes with a `/` path separator.